### PR TITLE
Remove default for onLinkPress prop to allow links to work by default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -109,7 +109,7 @@ const Markdown = ({
   markdownit = MarkdownIt({
     typographer: true,
   }),
-  onLinkPress = () => {},
+  onLinkPress,
   maxTopLevelChildren = null,
   topLevelMaxExceededItem = <Text>...</Text>,
   allowedImageHandlers = [


### PR DESCRIPTION
This fixes https://github.com/iamacup/react-native-markdown-display/issues/40