### PR TITLE
fix: Add `onLinkPress` to MarkdownProps

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -90,6 +90,7 @@ export interface MarkdownProps {
   markdownit?: MarkdownIt;
   mergeStyle?: boolean;
   debugPrintTree?: boolean;
+  onLinkPress: (url: string) => boolean;
 }
 
 type MarkdownStatic = React.ComponentType<MarkdownProps>;


### PR DESCRIPTION
Closes #73 