### PR TITLE
Changed onLinkPress prop definition to be optional

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -24,7 +24,7 @@ export type RenderLinkFunction = (
   children: ReactNode[],
   parentNodes: ASTNode[],
   styles: any,
-  onLinkPress: (url: string) => boolean,
+  onLinkPress?: (url: string) => boolean,
 ) => ReactNode;
 
 export type RenderImageFunction = (
@@ -90,7 +90,7 @@ export interface MarkdownProps {
   markdownit?: MarkdownIt;
   mergeStyle?: boolean;
   debugPrintTree?: boolean;
-  onLinkPress: (url: string) => boolean;
+  onLinkPress?: (url: string) => boolean;
 }
 
 type MarkdownStatic = React.ComponentType<MarkdownProps>;


### PR DESCRIPTION
The `onLinkPress` prop according to the code and the doc is optional but in the Typescript definition it is not optional. This PR fixes that.

For more references see:
https://github.com/iamacup/react-native-markdown-display/blob/a997c5e7e775298324238112f53a91eb3cdd01b5/src/lib/renderRules.js#L245

https://github.com/iamacup/react-native-markdown-display/blob/a997c5e7e775298324238112f53a91eb3cdd01b5/src/lib/util/openUrl.js#L4

https://github.com/iamacup/react-native-markdown-display/blame/3a40953000ae23ebbfb9fb057ac4622f15255f7e/README.md#L68

This issue is also related:
https://github.com/iamacup/react-native-markdown-display/issues/73