### PR TITLE
README: Remove heading style as it's a no-op.

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,10 +797,6 @@ import { SafeAreaView, ScrollView, StatusBar, StyleSheet } from 'react-native';
 import Markdown from 'react-native-markdown-display';
 
 const styles = StyleSheet.create({
-  heading: {
-    borderBottomWidth: 1,
-    borderColor: '#000000',
-  },
   heading1: {
     fontSize: 32,
     backgroundColor: '#000000',


### PR DESCRIPTION
The heading style was confusing in the README as it made it appear that all headings could be modified via one style. In actuality, every heading is styled individually. I'm guessing this error was made as the "Example Implementation" of Rules generates `<Text>` elements for headers that are styled by both heading & heading#.