### PR TITLE
fix: remove styles export from typings

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -81,8 +81,6 @@ export function stringToTokens(
 
 export function tokensToAST(tokens: ReadonlyArray<Token>): ASTNode[];
 
-export const styles: any;
-
 export interface MarkdownProps {
   rules?: RenderRules;
   style?: StyleSheet.NamedStyles<any>;


### PR DESCRIPTION
Not sure why it is exported but I think its wrong.