### PR TITLE
Disable screen reader announcement "dot" for unordered list items

### DIFF
--- a/src/lib/renderRules.js
+++ b/src/lib/renderRules.js
@@ -123,7 +123,9 @@ const renderRules = {
     if (hasParents(parent, 'bullet_list')) {
       return (
         <View key={node.key} style={styles._VIEW_SAFE_list_item}>
-          <Text style={[modifiedInheritedStylesObj, styles.bullet_list_icon]}>
+          <Text
+            style={[modifiedInheritedStylesObj, styles.bullet_list_icon]}
+            accessible={false}>
             {Platform.select({
               android: '\u2022',
               ios: '\u00B7',


### PR DESCRIPTION
This is a small fix that enables a screen reader to simply read the text for an unordered list without also verbosely announcing "dot" between each list item.