### PR TITLE
Improve style of blockquote

### DIFF
--- a/src/lib/styles.js
+++ b/src/lib/styles.js
@@ -50,9 +50,11 @@ export const styles = {
 
   // Blockquotes
   blockquote: {
-    paddingHorizontal: 14,
-    paddingVertical: 4,
-    backgroundColor: '#CCCCCC',
+    backgroundColor: "#F5F5F5",
+    borderColor: "#CCC",
+    borderLeftWidth: 4,
+    marginLeft: 5,
+    paddingHorizontal: 5,
   },
 
   // Lists


### PR DESCRIPTION
This updates the style of blockquote to match the format from https://www.markdownguide.org/basic-syntax/#blockquotes-1

before (iOS):
<img width="429" alt="before_ios" src="https://user-images.githubusercontent.com/456610/88527319-f1bbd000-cfb1-11ea-8848-1a13bba9a4dd.png">

after (iOS):
<img width="429" alt="after_ios" src="https://user-images.githubusercontent.com/456610/88527387-08fabd80-cfb2-11ea-928e-e45702a255c2.png">