### PR TITLE
Use monospace font for code (inline, block & fence)

### DIFF
--- a/src/lib/styles.js
+++ b/src/lib/styles.js
@@ -131,6 +131,14 @@ export const styles = {
     backgroundColor: '#f5f5f5',
     padding: 10,
     borderRadius: 4,
+    ...Platform.select({
+      ["ios"]: {
+        fontFamily: "Courier",
+      },
+      ["android"]: {
+        fontFamily: "monospace",
+      },
+    }),
   },
   code_block: {
     borderWidth: 1,
@@ -138,6 +146,14 @@ export const styles = {
     backgroundColor: '#f5f5f5',
     padding: 10,
     borderRadius: 4,
+    ...Platform.select({
+      ["ios"]: {
+        fontFamily: "Courier",
+      },
+      ["android"]: {
+        fontFamily: "monospace",
+      },
+    }),
   },
   fence: {
     borderWidth: 1,
@@ -145,6 +161,14 @@ export const styles = {
     backgroundColor: '#f5f5f5',
     padding: 10,
     borderRadius: 4,
+    ...Platform.select({
+      ["ios"]: {
+        fontFamily: "Courier",
+      },
+      ["android"]: {
+        fontFamily: "monospace",
+      },
+    }),
   },
 
   // Tables


### PR DESCRIPTION
This improves the rendering of code (code_inline, code code_block and fence) to use a monospace font.
Fonts that are installed by default on iOS / Android are chosen.

before (iOS):
<img width="436" alt="code_monospace_ios_before" src="https://user-images.githubusercontent.com/456610/89115794-27910680-d441-11ea-896c-49ab714dcf68.png">

after (iOS):
<img width="432" alt="code_monospace_ios_after" src="https://user-images.githubusercontent.com/456610/89115797-2bbd2400-d441-11ea-8298-c4c902f515f8.png">

before (Android):
<img width="358" alt="code_monospace_android_before" src="https://user-images.githubusercontent.com/456610/89115800-2f50ab00-d441-11ea-8a26-6af850a697df.png">

after (Android):
<img width="355" alt="code_monospace_android_after" src="https://user-images.githubusercontent.com/456610/89115801-337cc880-d441-11ea-85b4-1529dfdf1c81.png">