### PR TITLE
fix: actually use imported `ComponentType`

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -93,7 +93,7 @@ export interface MarkdownProps {
   onLinkPress?: (url: string) => boolean;
 }
 
-type MarkdownStatic = React.ComponentType<MarkdownProps>;
+type MarkdownStatic = ComponentType<MarkdownProps>;
 export const Markdown: MarkdownStatic;
 export type Markdown = MarkdownStatic;
 export {MarkdownIt};


### PR DESCRIPTION
This was reported as unused import, because line 96 used the `React.ComponentType` instead of the imported `ComponentType`.

Another fix would have been to remove the import.

Whats your pick? @iamacup 