### PR TITLE
Allow list item contents to wrap.

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,14 +177,14 @@ And some additional, less used options:
   + Sub-lists are made by indenting 2 spaces:
     - Marker character change forces new list start:
       * Ac tristique libero volutpat at
-      + Facilisis in pretium nisl aliquet
+      + Facilisis in pretium nisl aliquet. This is a very long list item that will surely wrap onto the next line.
       - Nulla volutpat aliquam velit
   + Very easy!
 
   Ordered
 
   1. Lorem ipsum dolor sit amet
-  2. Consectetur adipiscing elit
+  2. Consectetur adipiscing elit. This is a very long list item that will surely wrap onto the next line.
   3. Integer molestie lorem at massa
 
   Start numbering with offset:

--- a/README.md
+++ b/README.md
@@ -608,14 +608,14 @@ Lists
   + Sub-lists are made by indenting 2 spaces:
     - Marker character change forces new list start:
       * Ac tristique libero volutpat at
-      + Facilisis in pretium nisl aliquet
+      + Facilisis in pretium nisl aliquet. This is a very long list item that will surely wrap onto the next line.
       - Nulla volutpat aliquam velit
   + Very easy!
 
   Ordered
 
   1. Lorem ipsum dolor sit amet
-  2. Consectetur adipiscing elit
+  2. Consectetur adipiscing elit. This is a very long list item that will surely wrap onto the next line.
   3. Integer molestie lorem at massa
 
   Start numbering with offset:

--- a/src/lib/styles.js
+++ b/src/lib/styles.js
@@ -72,7 +72,6 @@ export const styles = {
   // @pseudo class, does not have a unique render rule
   bullet_list_content: {
     flex: 1,
-    flexWrap: 'wrap',
   },
   // @pseudo class, does not have a unique render rule
   ordered_list_icon: {
@@ -82,7 +81,6 @@ export const styles = {
   // @pseudo class, does not have a unique render rule
   ordered_list_content: {
     flex: 1,
-    flexWrap: 'wrap',
   },
 
   // Code


### PR DESCRIPTION
Fixes #120

ios:
<img width="433" alt="ios_list_item_wrap" src="https://user-images.githubusercontent.com/456610/96960872-4e972b80-14b8-11eb-9729-94a8d0906692.png">

android:
<img width="364" alt="android_list_item_wrap" src="https://user-images.githubusercontent.com/456610/96960847-417a3c80-14b8-11eb-9064-45612c973bfb.png">