### PR TITLE
Added sourceInfo and sourceMeta to ASTNode

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -53,6 +53,7 @@ export interface ASTNode {
   type: string;
   sourceType: string; // original source token name
   sourceInfo: string;
+  sourceMeta: string | null;
   key: string;
   content: string;
   markup: string;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -53,7 +53,7 @@ export interface ASTNode {
   type: string;
   sourceType: string; // original source token name
   sourceInfo: string;
-  sourceMeta: string | null;
+  sourceMeta: any;
   key: string;
   content: string;
   markup: string;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -52,6 +52,7 @@ export interface MarkdownParser {
 export interface ASTNode {
   type: string;
   sourceType: string; // original source token name
+  sourceInfo: string;
   key: string;
   content: string;
   markup: string;


### PR DESCRIPTION
In case you need syntax highlighting with Prism or something similar, you need to get the language of the code via node.sourceInfo like this:

```javascript
<Markdown
  rules={{
    // markdown-it renders code blocks as "fence".
    fence: (node) => {
      return (
        <CodeBlock
          key={node.key}
          plainCode={node.content}
          
          // Get the language
          lang={node.sourceInfo}
        />
      );
    },
  }}
>
  {wholeMarkdown}
</Markdown>
```

And then the component:

```javascript
import Prism from 'prismjs';

interface Props {
  plainCode: string;
  lang: string;
}

const CodeBlock: React.FC<Props> = ({ plainCode, lang }) => {
  let highlightedCode: string = '';
  try {
    highlightedCode = Prism.highlight(plainCode, Prism.languages[lang], lang);
  } catch (_) {
    highlightedCode = plainCode;
  }

  return (
    <View>
      // Use react-native-webview to show the highlighted code.
    </View>
  );
};
```
---
**Edit:** Added sourceMeta as requested in #130.