### PR TITLE
fix children typing on MarkdownStatic

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,7 +1,7 @@
 // tslint:disable:max-classes-per-file
 import MarkdownIt from 'markdown-it';
 import Token from 'markdown-it/lib/token';
-import {ComponentType, ReactNode} from 'react';
+import {ComponentType, PropsWithChildren, ReactNode} from 'react';
 import {StyleSheet, View} from 'react-native';
 
 export function getUniqueID(): string;
@@ -91,7 +91,7 @@ export interface MarkdownProps {
   onLinkPress?: (url: string) => boolean;
 }
 
-type MarkdownStatic = ComponentType<MarkdownProps>;
+type MarkdownStatic = ComponentType<PropsWithChildren<MarkdownProps>>;
 export const Markdown: MarkdownStatic;
 export type Markdown = MarkdownStatic;
 export {MarkdownIt};


### PR DESCRIPTION
As things stand, this code
<img width="349" alt="image" src="https://github.com/iamacup/react-native-markdown-display/assets/25273007/8089cda2-46c4-4871-8602-73291973fb87">

causes this typescript error
<img width="642" alt="image" src="https://github.com/iamacup/react-native-markdown-display/assets/25273007/53be11a9-d4e0-4178-a93a-3ca612152e54">

This is a simple fix to add children to the accepted props of the Markdown component.