### PR TITLE
Fixed props key was spread into JSX FitImage

### DIFF
--- a/src/lib/renderRules.js
+++ b/src/lib/renderRules.js
@@ -284,7 +284,6 @@ const renderRules = {
 
     const imageProps = {
       indicator: true,
-      key: node.key,
       style: styles._VIEW_SAFE_image,
       source: {
         uri: show === true ? src : `${defaultImageHandler}${src}`,
@@ -296,7 +295,7 @@ const renderRules = {
       imageProps.accessibilityLabel = alt;
     }
 
-    return <FitImage {...imageProps} />;
+    return <FitImage key={node.key} {...imageProps} />;
   },
 
   // Text Output


### PR DESCRIPTION
Hi,

With the last version of react-native (0.75.4), the package display a warning for a deprecated code :

```
 ERROR  Warning: A props object containing a "key" prop is being spread into JSX:
  let props = {key: someKey, indicator: ..., style: ..., source: ..., accessible: ..., accessibilityLabel: ...};
  <FitImage {...props} />
React keys must be passed directly to JSX without using spread:
  let props = {indicator: ..., style: ..., source: ..., accessible: ..., accessibilityLabel: ...};
  <FitImage key={someKey} {...props} />
  ```

So I create this PR to fix it. As you can see, it’s really a light commit.

This PR work with last react-native version and previous one.

Do you think create a new npm patch 7.0.3 to add this modification ?


Thanks for reading.